### PR TITLE
Add include guard to header

### DIFF
--- a/nu_malloc.h
+++ b/nu_malloc.h
@@ -1,8 +1,13 @@
-// Included for the `size_t` type. 
-#include <string.h>
+#ifndef NU_MALLOC_H
+#define NU_MALLOC_H
+
+// Included for the `size_t` type.
+#include <stddef.h>
 
 // Declare function prototypes
 void* nu_malloc(size_t);
 void* nu_calloc(size_t, size_t);
 void* nu_realloc(void*, size_t);
 void nu_free(void*);
+
+#endif


### PR DESCRIPTION
## Summary
- wrap `nu_malloc.h` with an include guard
- include `<stddef.h>` instead of `<string.h>`
- ensure file ends with a newline

## Testing
- `gcc -c nu_malloc.c -o /tmp/nu_malloc.o` *(fails: implicit functions and missing headers)*

------
https://chatgpt.com/codex/tasks/task_b_68435c4abccc8324872e4a23fea84032