### PR TITLE
Handle mmap failure

### DIFF
--- a/nu_malloc.c
+++ b/nu_malloc.c
@@ -16,6 +16,10 @@ void *nu_malloc (size_t size) {
 
     /* Allocate memory using mmap */
     plen = mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+    /* Check if mmap failed */
+    if (plen == MAP_FAILED) {
+        return NULL;
+    }
 
     /* Store the length of allocated memory in the first 4 bytes */
     *plen = len;                   


### PR DESCRIPTION
## Summary
- check whether `mmap` returned `MAP_FAILED`

## Testing
- `gcc -c nu_malloc.c` *(fails: conflicting types for `nu_free`)*

------
https://chatgpt.com/codex/tasks/task_b_68435e46ffc083249ab8c439d061eef0