### PR TITLE
Fix comment to mention sizeof(size_t)

### DIFF
--- a/nu_malloc.c
+++ b/nu_malloc.c
@@ -23,7 +23,7 @@ void *nu_malloc (size_t size) {
         return NULL;
     }
 
-    /* Store the length of allocated memory in the first 4 bytes */
+    /* Store the length of allocated memory in the first sizeof(size_t) bytes */
     *plen = len;                   
 
     /* Return a pointer to the memory after the length variable */


### PR DESCRIPTION
## Summary
- clarify how many bytes are used to store the block length

## Testing
- `make clean && make`


------
https://chatgpt.com/codex/tasks/task_b_684361ca2a7483248aefa66191c3d710