### PR TITLE
Add script and target to verify example output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,13 @@ nu_malloc.o: nu_malloc.c nu_malloc.h
 clean:
 	rm -f example *.o
 
-.PHONY: all clean
+test: example
+	@echo "Running example..." && \
+	output=`./example` && \
+	if [ "$$output" = "Value: 42" ]; then \
+		echo "$$output"; \
+	else \
+		echo "Unexpected output: $$output"; exit 1; \
+	fi
+
+.PHONY: all clean test

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ To compile manually without `make`:
 gcc -std=c11 example.c nu_malloc.c -o example
 ```
 
+### Testing
+
+Run the `test_example.sh` script to build `example` and verify its output:
+
+```
+./test_example.sh
+```
+
+The script expects the program to print `Value: 42`.
+
 ## **Note**
 This is a sample code and is not recommended for production use. It is recommended to test it thoroughly before using it in production.
 

--- a/test_example.sh
+++ b/test_example.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Build the example program
+make example > /dev/null
+
+# Run the program and capture its output
+output=$(./example)
+
+if [ "$output" = "Value: 42" ]; then
+    echo "Test passed: $output"
+else
+    echo "Test failed: expected 'Value: 42', got '$output'" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add `test_example.sh` to build and run example
- add `test` target to `Makefile`
- document new testing step in `README`

## Testing
- `make test`
- `./test_example.sh`


------
https://chatgpt.com/codex/tasks/task_b_684361cf9f988324bc078c4c881ac506