### PR TITLE
Propagate mmap errno and extend failure tests

### DIFF
--- a/nu_malloc.c
+++ b/nu_malloc.c
@@ -28,7 +28,6 @@ void *nu_malloc (size_t size) {
 #ifdef _POSIX_VERSION
     plen = mmap(0, len, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
     if (plen == MAP_FAILED) {
-        errno = ENOMEM;
         return NULL;
     }
 #else


### PR DESCRIPTION
## Summary
- let `nu_malloc` return MAP_FAILED errno
- simulate mmap failure in tests using RLIMIT_AS and ensure errno propagates

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_684369bc67648324bd3c12868570d099