### PR TITLE
Fix size_t header comment

### DIFF
--- a/nu_malloc.c
+++ b/nu_malloc.c
@@ -1,4 +1,5 @@
-// Included for the `size_t` type.
+// <stddef.h> defines size_t; <string.h> provides memcpy and memset.
+#include <stddef.h>
 #include <string.h>
 #ifdef _POSIX_VERSION
 #include <sys/mman.h>


### PR DESCRIPTION
## Summary
- clarify which headers define `size_t` and memory helpers
- add `<stddef.h>` include to `nu_malloc.c`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_b_68439b170ab48324adfc90f70179f57f