### PR TITLE
Add memset_s usage when available

### DIFF
--- a/nu_malloc.c
+++ b/nu_malloc.c
@@ -1,5 +1,7 @@
-// <stddef.h> defines size_t; <string.h> provides memcpy and memset.
+// <stddef.h> defines size_t; <string.h> provides memcpy and memset or memset_s.
 #include <stddef.h>
+// Request optional bounds-checking interfaces (memset_s)
+#define __STDC_WANT_LIB_EXT1__ 1
 #include <string.h>
 #ifdef _POSIX_VERSION
 #include <sys/mman.h>
@@ -60,8 +62,13 @@ void *nu_calloc (size_t count, size_t eltsize) {
     /* Allocate memory */
     void *value = nu_malloc (size);
     /* Clear the memory */
-    if (value != 0)
-        memset (value, 0, size);
+    if (value != 0) {
+#ifdef __STDC_LIB_EXT1__
+        memset_s(value, size, 0, size);
+#else
+        memset(value, 0, size);
+#endif
+    }
     return value;
 }
 


### PR DESCRIPTION
## Summary
- request Annex K functions from `<string.h>`
- use `memset_s` in `nu_calloc` when available

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6843adf635808324bccbad79d0eb9612