### PR TITLE
Fix clean rule to remove library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ nu_malloc.o: nu_malloc.c nu_malloc.h
 libnu_malloc.a: nu_malloc.o
 	$(AR) rcs $@ nu_malloc.o
 clean:
-	rm -f example memory_test *.o
+	rm -f example memory_test libnu_malloc.a *.o
 
 test: example memory_test
 	@./test_example.sh


### PR DESCRIPTION
## Summary
- update Makefile so `make clean` also removes `libnu_malloc.a`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6843cfb4be088324aae0b79c531b63d8