### PR TITLE
Improve allocator portability and install support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
 CC ?= gcc
-CFLAGS ?= -std=c11 -Wall -Wextra -pedantic
+CFLAGS ?= -std=c11 -Wall -Wextra -pedantic -fPIC
 AR ?= ar
+PREFIX ?= /usr/local
+INCLUDEDIR ?= $(PREFIX)/include
+LIBDIR ?= $(PREFIX)/lib
 
-all: libnu_malloc.a example memory_test
+all: libnu_malloc.a libnu_malloc.so example memory_test
 
 example: example.o nu_malloc.o
 	$(CC) $(CFLAGS) -o $@ example.o nu_malloc.o
@@ -20,12 +23,22 @@ nu_malloc.o: nu_malloc.c nu_malloc.h
 	$(CC) $(CFLAGS) -c nu_malloc.c
 
 libnu_malloc.a: nu_malloc.o
-	$(AR) rcs $@ nu_malloc.o
+	        $(AR) rcs $@ nu_malloc.o
+
+libnu_malloc.so: nu_malloc.o
+	$(CC) $(CFLAGS) -shared -o $@ nu_malloc.o
 clean:
-	rm -f example memory_test libnu_malloc.a *.o
+	rm -f example memory_test libnu_malloc.a libnu_malloc.so *.o
 
 test: example memory_test
 	@./test_example.sh
 	@./test_memory.sh
 
-.PHONY: all clean test
+install: libnu_malloc.a libnu_malloc.so
+	install -d $(DESTDIR)$(INCLUDEDIR)
+	install -m 644 nu_malloc.h $(DESTDIR)$(INCLUDEDIR)/
+	install -d $(DESTDIR)$(LIBDIR)
+	install -m 644 libnu_malloc.a $(DESTDIR)$(LIBDIR)/
+	install -m 755 libnu_malloc.so $(DESTDIR)$(LIBDIR)/
+
+.PHONY: all clean test install

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ and `free` routines. The code lives in `nu_malloc.c` and its header
 ## Usage
 
 To use the custom memory functions, include `nu_malloc.h` in your program.
-Call its functions just like their standard library counterparts. The
+The header is C++ friendly and wraps the declarations in `extern "C"`
+when included from C++ code. Call the functions just like their standard
+library counterparts. The
 function prototypes are as follows:
 ```c
 
@@ -36,8 +38,9 @@ function prototypes are as follows:
 ## Building
 
 A simple `Makefile` is included. The project uses `mmap` and `munmap` on
-POSIX systems. When `_POSIX_VERSION` is undefined on Windows the code
-falls back to the standard `malloc` family.
+POSIX systems. When `_POSIX_VERSION` is undefined the code falls back to
+the standard `malloc` family. Both a static library (`libnu_malloc.a`)
+and a shared library (`libnu_malloc.so`) are produced.
 
 ### POSIX systems
 
@@ -68,6 +71,21 @@ To build just the static library:
 ```
 make libnu_malloc.a
 ```
+
+To build just the shared library:
+
+```
+make libnu_malloc.so
+```
+
+You can install the header and libraries with:
+
+```
+make install
+```
+
+The install location can be customized with `PREFIX`, `INCLUDEDIR` and
+`LIBDIR` variables. The defaults install into `/usr/local`.
 
 ### Windows (MinGW/MSVC)
 

--- a/memory_test.c
+++ b/memory_test.c
@@ -126,6 +126,21 @@ int main(void) {
         return 1;
     }
 
+    int *small = (int *)nu_malloc(sizeof(int));
+    if (!small) {
+        perror("nu_malloc small");
+        return 1;
+    }
+    errno = 0;
+    void *realloc_fail = nu_realloc(small, SIZE_MAX);
+    if (realloc_fail != NULL || errno != ENOMEM) {
+        fprintf(stderr, "nu_realloc SIZE_MAX should fail with ENOMEM\n");
+        nu_free(realloc_fail);
+        nu_free(small);
+        return 1;
+    }
+    nu_free(small);
+
 #ifdef _POSIX_VERSION
     /* Simulate mmap failure by limiting address space */
     struct rlimit orig_lim;

--- a/nu_malloc.c
+++ b/nu_malloc.c
@@ -7,6 +7,12 @@
 #include <string.h>
 #ifdef _POSIX_VERSION
 #include <sys/mman.h>
+/* Some BSD variants use MAP_ANON instead of MAP_ANONYMOUS */
+#ifndef MAP_ANONYMOUS
+#ifdef MAP_ANON
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#endif
 #else
 #include <stdlib.h>
 #endif
@@ -40,6 +46,7 @@ void *nu_malloc (size_t size) {
 #else
     plen = (size_t*)malloc(len);
     if (plen == NULL) {
+        errno = ENOMEM;
         return NULL;
     }
 #endif
@@ -112,6 +119,7 @@ void *nu_realloc (void *ptr, size_t size) {
     size_t new_len = size + HEADER_SIZE;
     size_t* newbase = realloc(plen, new_len);
     if (newbase == NULL) {
+        errno = ENOMEM;
         return NULL;
     }
     *newbase = new_len;

--- a/nu_malloc.h
+++ b/nu_malloc.h
@@ -5,10 +5,18 @@
 // Included for the `size_t` type.
 #include <stddef.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Declare function prototypes
 void* nu_malloc(size_t);
 void* nu_calloc(size_t, size_t);
 void* nu_realloc(void*, size_t);
 void nu_free(void*);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
## Summary
- wrap `nu_malloc.h` declarations in `extern "C"` for C++ users
- improve `mmap` portability and ensure `errno` is set on allocation failure
- add shared library build and install targets
- document installation, shared builds and C++ usage
- test that `nu_realloc` sets `errno` on failure

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6843ea39420c83248fde6494cc748084