### PR TITLE
Add CI matrix across OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,13 @@ on:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v3
       - name: Build


### PR DESCRIPTION
## Summary
- extend CI to run on ubuntu, macOS and Windows
- force bash shell so Windows can run `make` commands

## Testing
- `make clean && make && make test`

------
https://chatgpt.com/codex/tasks/task_b_6843ee646bc48324a24e68d406d4e501