### PR TITLE
Add CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.10)
+project(nu_malloc C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/build)
+
+add_library(nu_malloc_static STATIC src/nu_malloc.c)
+set_target_properties(nu_malloc_static PROPERTIES
+    OUTPUT_NAME nu_malloc
+    POSITION_INDEPENDENT_CODE ON)
+target_include_directories(nu_malloc_static PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+add_library(nu_malloc_shared SHARED src/nu_malloc.c)
+set_target_properties(nu_malloc_shared PROPERTIES
+    OUTPUT_NAME nu_malloc
+    POSITION_INDEPENDENT_CODE ON)
+target_include_directories(nu_malloc_shared PUBLIC ${PROJECT_SOURCE_DIR}/include)
+
+add_executable(example src/example.c)
+target_include_directories(example PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(example PRIVATE nu_malloc_static)
+
+add_executable(memory_test tests/memory_test.c)
+target_include_directories(memory_test PRIVATE ${PROJECT_SOURCE_DIR}/include)
+target_link_libraries(memory_test PRIVATE nu_malloc_static)
+
+enable_testing()
+add_test(NAME example_test
+    COMMAND ${PROJECT_SOURCE_DIR}/tests/test_example.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/example)
+add_test(NAME memory_test
+    COMMAND ${PROJECT_SOURCE_DIR}/tests/test_memory.sh ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/memory_test)
+
+install(TARGETS nu_malloc_static nu_malloc_shared
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib)
+install(FILES include/nu_malloc.h DESTINATION include)
+

--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ make install
 
 The install location can be customized with `PREFIX`, `INCLUDEDIR` and
 `LIBDIR` variables. The defaults install into `/usr/local`.
+### Using CMake
+
+```sh
+cmake -B build
+cmake --build build
+```
+
+This will place `libnu_malloc.a`, `libnu_malloc.so`, `example` and `memory_test` inside the `build/` directory. To run the tests use:
+
+```sh
+cd build && ctest
+```
+
 
 ### Windows (MinGW/MSVC)
 


### PR DESCRIPTION
## Summary
- add a CMake build that mirrors the Makefile outputs
- document how to build and test with CMake

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_6843ee62a3a48324857d3d687eb425ac