### PR TITLE
Fix CRLF issue for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
- add a `.gitattributes` file so shell scripts stay LF on Windows

## Testing
- `make test`
- `shellcheck tests/test_memory.sh`


------
https://chatgpt.com/codex/tasks/task_b_6843f1cca11c8324a72e111c1699777b