### PR TITLE
Fix Windows build by installing GCC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
           elif [[ "$RUNNER_OS" == "macOS" ]]; then
             brew install shellcheck
           elif [[ "$RUNNER_OS" == "Windows" ]]; then
-            choco install -y shellcheck
+            choco install -y shellcheck make mingw
+            echo "C:\\ProgramData\\mingw64\\mingw64\\bin" >> "$GITHUB_PATH"
+            echo "C:\\ProgramData\\chocolatey\\lib\\make\\tools\\GnuWin32\\bin" >> "$GITHUB_PATH"
+            echo "CC=gcc" >> "$GITHUB_ENV"
           fi
       - name: Lint Shell Scripts
         run: shellcheck tests/*.sh


### PR DESCRIPTION
## Summary
- fix path for MinGW
- set CC=gcc on Windows

## Testing
- `shellcheck tests/*.sh`
- `make && make test`


------
https://chatgpt.com/codex/tasks/task_b_6843f2c76f10832480e0b612e4566987