### PR TITLE
Fix Makefile CC value to use gcc on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Build settings
-CC ?= gcc
+CC = gcc
 CFLAGS ?= -std=c11 -Wall -Wextra -pedantic -fPIC -Iinclude
 AR ?= ar
 PREFIX ?= /usr/local


### PR DESCRIPTION
## Summary
- fix windows CI failure by explicitly setting `CC = gcc`

## Testing
- `shellcheck tests/*.sh`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6843f5b478a48324b81bb21b088bcdd8